### PR TITLE
Read ImageMagick version info from the magick --version command output

### DIFF
--- a/src/test/java/com/jetbrains/marco/EnabledIfImageMagickInstalledCondition.java
+++ b/src/test/java/com/jetbrains/marco/EnabledIfImageMagickInstalledCondition.java
@@ -10,7 +10,7 @@ public class EnabledIfImageMagickInstalledCondition implements ExecutionConditio
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
         return findAnnotation(extensionContext.getElement(), EnabledIfImageMagickIsInstalled.class) //
-                .map((annotation) -> (new App.ImageMagick().detectVersion() != App.ImageMagick.Version.NA)
+                .map((annotation) -> new App.ImageMagick().detectVersion() != null
                         ? ConditionEvaluationResult.enabled("ImageMagick installed.")
                         : ConditionEvaluationResult.disabled("No ImageMagick installation found.")) //
                 .orElse(ConditionEvaluationResult.disabled("By default, Imagemagick tests are disabled"));

--- a/src/test/java/com/jetbrains/marco/ImageMagickTest.java
+++ b/src/test/java/com/jetbrains/marco/ImageMagickTest.java
@@ -20,7 +20,7 @@ class ImageMagickTest {
 
     @Test
     void imageMagick_is_installed() {
-        assertThat(imageMagick.detectVersion()).isNotEqualTo(App.ImageMagick.Version.NA);
+        assertThat(imageMagick.detectVersion()).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/jetbrains/marco/ImageMagickVersionTest.java
+++ b/src/test/java/com/jetbrains/marco/ImageMagickVersionTest.java
@@ -1,0 +1,70 @@
+package com.jetbrains.marco;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ImageMagickVersionTest {
+    /**
+     * Wraps test version output string and the expected parse results.
+     *
+     * @param output          Version line as returned by magick --version or convert --version commands.
+     * @param expectedVersion Expected version data.
+     */
+    private record VersionInfoTestData(String output, App.ImageMagick.Version expectedVersion) {
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideVersionInfoTestData")
+    public void can_parse_ImageMagick_output(VersionInfoTestData versionInfo) {
+        final var version = App.ImageMagick.Version.fromImageMagickOutput(versionInfo.output);
+
+        assertThat(version).isNotNull();
+        assertThat(version.major()).isEqualTo(versionInfo.expectedVersion.major());
+        assertThat(version.minor()).isEqualTo(versionInfo.expectedVersion.minor());
+        assertThat(version.patch()).isEqualTo(versionInfo.expectedVersion.patch());
+
+        if (versionInfo.expectedVersion.build().isPresent()) {
+            assertThat(version.build().isPresent()).isTrue();
+            assertThat(version.build().get()).isEqualTo(versionInfo.expectedVersion.build().get());
+        } else {
+            assertThat(version.build().isEmpty()).isTrue();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidVersionOutputs")
+    public void fromImageMagickOutput_returns_null_on_invalid_version_outputs(String versionOutput) {
+        assertThat(App.ImageMagick.Version.fromImageMagickOutput(versionOutput)).isNull();
+    }
+
+    private static VersionInfoTestData[] provideVersionInfoTestData() {
+        return new VersionInfoTestData[]{
+                // ImageMagick 7
+                new VersionInfoTestData("Version: ImageMagick 7.1.0-58 Q16-HDRI x86_64 20802 https://imagemagick.org",
+                        new App.ImageMagick.Version(7, 1, 0, Optional.of(58))),
+                // ImageMagick 6
+                new VersionInfoTestData("Version: ImageMagick 6.9.12-73 Q16 x86_64 17646 https://legacy.imagemagick.org",
+                        new App.ImageMagick.Version(6, 9, 12, Optional.of(73))),
+                // ImageMagick without build data
+                new VersionInfoTestData("Version: ImageMagick 7.1.0 Q16-HDRI x86_64 20802 https://imagemagick.org",
+                        new App.ImageMagick.Version(7, 1, 0, Optional.empty())),
+        };
+    }
+
+    private static String[] provideInvalidVersionOutputs() {
+        return new String[]{
+                "Version: ImageMagick 7.1-24",
+                "Version: ImageMagick 7.1",
+                "Version: ImageMagick 7",
+                "asdfasdf 1.2.3-5",
+                "asdfasdf 1.2.3",
+                "1.2.3-5",
+                "1.2.3",
+                ""
+        };
+    }
+}


### PR DESCRIPTION
As requested in https://youtu.be/Dr0WN-Bu1oA?t=563 :P

Pull request into the proper branch instead of https://github.com/marcobehlerjetbrains/google-photos-clone/pull/1 :).

I tried to introduce the least amount of changes to the code possible to avoid interference with the ongoing refactoring. I created a `Version` record in the `ImageMagick` class which represents the ImageMagick version fields (major, minor, patch and optional build). It has a static constructor `fromImageMagickOutput` which parses the provided output string. If the string has incorrect format it returns `null`. It would be better to throw an exception instead but I wasn't sure how to integrate it with the static nature of the ImageMagick class so I just went with the existing code style as much as possible. I also added tests for the parsing algorithm.

The output reading is done in the `detectVersion` method of the `ImageMagick` class. It sequentially runs an array of possible commands that return ImageMagick version info and reads the output. If none of the commands exit successfully or returned parseable output the method returns `null`. Otherwise an instance of the `Version` record is returned.

I understand that running a set of commands is an expensive way to determine version. The proper way to do that would be to check the `PATH` environment variable for the ImageMagick commands and run the first match to get the version info. Java however doesn't have a simple way to check whether a command is accessible in `PATH` (besides executing it and catching exceptions) so the only way to find out is to either use a third-party library or parse the `PATH` variable and check directories manually. I believe that either approach is beyond the scope of this project at least at its current state so I went with the simplest albeit slow method.
